### PR TITLE
Add hostLoadArray to lsf.i

### DIFF
--- a/pythonlsf/lsf.i
+++ b/pythonlsf/lsf.i
@@ -54,6 +54,7 @@ PyObject * string_array_to_pylist(PyObject* ptrobj, int size){
 
 %array_class(struct queueInfoEnt, queueInfoEntArray);
 %array_class(struct hostInfoEnt, hostInfoEntArray);
+%array_class(struct hostLoad, hostLoadArray);
 
 // handle int arrays
 %typemap(in) int [ANY] (int temp[$1_dim0]) {


### PR DESCRIPTION
The return value of ls_load() is an array of hostLoad structures. This means that hostLoad must be converted to an hostLoadArray before being processed. This commit add that structure.
