### PR TITLE
add example for restarting RES daemons on  specified 1 or multiple hosts

### DIFF
--- a/examples/restartRES.py
+++ b/examples/restartRES.py
@@ -1,0 +1,28 @@
+import sys,socket
+from pythonlsf import lsf
+
+def restartres(hostlist):
+    if lsf.ls_initdebug("resrestart") < 0:
+       print("ls_initdebug failed!")
+       return -1
+    num_port = len(hostlist) * 2
+    if lsf.ls_initrex(num_port, 0) < num_port :
+        lsf.ls_perror("ls_initrex")
+        return -1
+    for host in hostlist:
+        rc=lsf.ls_rescontrol(host, lsf.RES_CMD_REBOOT, 0)
+    
+        if rc < 0:
+            lsf.ls_perror("lsf.ls_rescontrol")
+            print("failed restart res on {}".format(host))
+        else :
+            print("res on {} restarted".format(host))
+    return 
+
+if __name__ == '__main__':
+    if len(sys.argv) > 1 :
+        hostlist = sys.argv[1:]
+    else :
+        hostlist = [socket.gethostname()]
+    restartres(hostlist)
+


### PR DESCRIPTION
UT:
1. default restart local res
```
[root@yanlidev1 examples]# lsgrun -m "yanlidev1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      5852     1  0 01:04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      6937  5852  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
[root@yanlidev1 examples]# python restartRES.py
res on yanlidev1.fyre.ibm.com restarted
[root@yanlidev1 examples]# lsgrun -m "yanlidev1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      7125     1  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      7177  7125  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
```
2. specify 1 host
```
[root@yanlidev1 examples]# lsgrun -m "yanlidev1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      7125     1  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      7177  7125  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
[root@yanlidev1 examples]# python restartRES.py yanlidev1
res on yanlidev1 restarted
[root@yanlidev1 examples]# lsgrun -m "yanlidev1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      7488     1  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      7543  7488  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
```
3. specify 2 hosts
```
[root@yanlidev1 examples]# lsgrun -m "yanlidev1 malpha1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      7488     1  0 01:05 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      9175  7488  0 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      241353       1  0 00:59 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      242305  241353  0 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
[root@yanlidev1 examples]# python restartRES.py yanlidev1 malpha1
res on yanlidev1 restarted
res on malpha1 restarted
[root@yanlidev1 examples]# lsgrun -m "yanlidev1 malpha1" ps -ef | grep c101 | grep res
root      5167  5158  0 Sep04 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/mgres
root      9465     1  0 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      9625  9465  0 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      242339       1  0 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
root      242355  242339  1 01:07 ?        00:00:00 /scratch/lsf101/c101/10.1/linux3.10-glibc2.17-x86_64/etc/res
```