### PR TITLE
Added 0 to open('{}/lsf.conf'.... to prevent ValueError: zero length …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ gccflag_lsfversion = '-DNOLSFVERSION'
 def set_gccflag_lsf_version():
     global gccflag_lsfversion 
     _lsf_envdir = os.environ['LSF_ENVDIR']
-    with open('{}/lsf.conf'.format(_lsf_envdir), 'r') as f:
+    with open('{0}/lsf.conf'.format(_lsf_envdir), 'r') as f:
         _lsf_version = re.search('LSF_VERSION=(.*)', f.read()).group(1).strip() 
     if _lsf_version == '10.1' :
         gccflag_lsfversion= '-DLSF_VERSION_101'


### PR DESCRIPTION
…field name in format

[lsf-python-api]# python setup.py build
Traceback (most recent call last):
  File "setup.py", line 81, in <module>
    set_gccflag_lsf_version()
  File "setup.py", line 54, in set_gccflag_lsf_version
    with open('{}/lsf.conf'.format(_lsf_envdir), 'r') as f:
ValueError: zero length field name in format