### PR TITLE
add str2GpuJobData

### DIFF
--- a/pythonlsf/lsf.i
+++ b/pythonlsf/lsf.i
@@ -25,6 +25,7 @@ int fclose(FILE *f);
 #include "lsf.h"
 #include "lsbatch.h"
 #include "lib.table.h"
+extern struct gpuJobData* str2GpuJobData(char *str);
 %}
 
 %pointer_functions(int, intp)
@@ -47,6 +48,10 @@ int fclose(FILE *f);
 %array_functions(struct shareAcctInfoEnt, shareAcctInfoEntArray)
 #ifdef LSF_VERSION_101
 %array_functions(struct gpuRusage, gpuRusageArray)
+%array_functions(struct gpuJobHostData, gpuJobHostDataArray)
+%array_functions(struct gpuTaskData, gpuTaskDataArray)
+%array_functions(struct gpuData *, gpuDataArray)
+%array_functions(struct migData, migDataArray)
 #endif
 %array_functions(LS_LONG_INT, LS_LONG_INTArray)
 %array_functions(guaranteedResourcePoolEnt, guaranteedResourcePoolEntArray)
@@ -702,6 +707,9 @@ int get_lsb_errno() {
 
 char * get_lsb_sysmsg() {
     return lsb_sysmsg();
+}
+struct gpuJobData* get_str2GpuJobData(char *str) {
+    return str2GpuJobData(str);
 }
 
 PyObject * get_pids_from_stream(struct jRusage * jrusage) {


### PR DESCRIPTION
add str2GpuJobData

example:
```
def displayGpuJobTaskData(taskDataEnt):
    for i in range(taskDataEnt.ngpus):
        gdataEnt = lsf.gpuDataArray_getitem(taskDataEnt.gdata, i)
        print("       gpu id %d MTOTAL %d"  
            % (gdataEnt.id, gdataEnt.bdata.mtotal))
    for i in range(taskDataEnt.numMigs):
        migEnt = lsf.migDataArray_getitem(taskDataEnt.migs, i)
        print("       mig[%d]: migMem %d MTOTAL %d" 
            % (i, migEnt.migMem, migEnt.bdata.mtotal))
                            
     
def displayGpuJobData(str):
    gJobData = lsf.get_str2GpuJobData(str)
    if gJobData is None:
         return

    for j in range(gJobData.num_hosts):
        gJobHostDataEnt = lsf.gpuJobHostDataArray_getitem(gJobData.hData, j)
        print("gpuJobData host[%d]: hostname %s ngpus %d memrsv %d" 
              % (j, gJobHostDataEnt.hostname, gJobHostDataEnt.ngpus, gJobHostDataEnt.memrsv))
        for t in range(gJobHostDataEnt.num_task):
            taskDataEnt = lsf.gpuTaskDataArray_getitem(gJobHostDataEnt.tdata, t)
            print("gpuTask[%d]: taskid %d ngpus %d numMigs %d" 
                  % (t, taskDataEnt.taskid, taskDataEnt.ngpus, taskDataEnt.numMigs))
            displayGpuJobTaskData(taskDataEnt)
    for k in range(gJobData.numkvs) :
        gJobDataKeyEnt = lsf.keyValArray_getitem(gJobData.kvs, k)
        print("%s=%s" % ( gJobDataKeyEnt.key, gJobDataKeyEnt.val))

                                          

```